### PR TITLE
Add ability to ignore properties. Ignore message property for TSInteractions.

### DIFF
--- a/src/Messages/Interactions/TSInteraction.m
+++ b/src/Messages/Interactions/TSInteraction.m
@@ -54,6 +54,14 @@
     return [TSThread fetchObjectWithUniqueID:self.uniqueThreadId];
 }
 
++ (MTLPropertyStorage)storageBehaviorForPropertyWithKey:(NSString *)propertyKey {
+    if ([propertyKey isEqualToString:@"message"]) {
+        return MTLPropertyStorageNone;
+    }
+
+    return [super storageBehaviorForPropertyWithKey:propertyKey];
+}
+
 #pragma mark Date operations
 
 - (uint64_t)millisecondsTimestamp {


### PR DESCRIPTION
Otherwise it would try to store the message inside the database, causing a crash because it's not NSCoding compliant. 